### PR TITLE
Fix broken latestVersion URL in 2.2.0 index.html

### DIFF
--- a/releases/2.2.0/index.html
+++ b/releases/2.2.0/index.html
@@ -134,7 +134,7 @@
     var respecConfig = {
       postProcess: [quickreference],
       edDraftURI: "https://semiceu.github.io/Core-Business-Vocabulary/releases/2.2.0",
-      latestVersion: "https://semiceu.github.io/Core-Business-Vocabulary/releases2.2.0/",
+      latestVersion: "https://semiceu.github.io/Core-Business-Vocabulary/releases/2.2.0/",
       specStatus: "LD",
       publishDate: "2024-05-06",
       editors: myeditors,


### PR DESCRIPTION
Currently the "Latest published version" in this page

https://semiceu.github.io/Core-Business-Vocabulary/releases/2.2.0/

has missing `/` between "releases" and "2.2.0".

--

Unrelated to this PR, but there is also inconsistency of having/not having a trailing slash between these two URLs:
- Latest published version
- Latest editor's draft
